### PR TITLE
Initializing logger earlier

### DIFF
--- a/Inf3/server/server/Server.java
+++ b/Inf3/server/server/Server.java
@@ -163,12 +163,12 @@ public class Server implements ITokenizable, IListenable<IServerListener>,
 	 */
 	public Server(final String _port, final File _mapFile) throws IOException {
 		try {
-			port = Integer.parseInt(_port);
-			socket = new ServerSocket(port);
-			map = new ServerMap(_mapFile, this);
 			logger.accept(MessageType.GENERIC, MessageType.INFO,
 					MessageType.ERROR, MessageType.NOTIFICATION,
 					MessageType.OUTPUT, MessageType.DEBUG);
+			port = Integer.parseInt(_port);
+			socket = new ServerSocket(port);
+			map = new ServerMap(_mapFile, this);
 			map.getListeners().add(this);
 			getListeners().add(map);
 			serverCommands.addSubcommand(new HelpCommand());


### PR DESCRIPTION
Error messages related to port parsing and socket opening will now be
printed too.
